### PR TITLE
Bugfix/fix update guest network

### DIFF
--- a/compal/__init__.py
+++ b/compal/__init__.py
@@ -1083,120 +1083,29 @@ class WifiGuestNetworkSettings(object):
     @property
     def wifi_guest_network_settings(self):
         """
-        Read the wifi guest network settings
+        Read the current wifi guest network settings for all wifi bands (2g and 5g).
         """
         xml = self.wifi_guest_network_settings_xml
-        guest_networks_2g = WifiGuestNetworkSettings.__band_guest_networks(xml, "2g")
-        guest_networks_5g = WifiGuestNetworkSettings.__band_guest_networks(xml, "5g")
+        # the compal modem returns 7 entries per band, the only used element is index 2
+        one_and_only_relevant_index = 2
+        guest_networks_2g = WifiGuestNetworkSettings.__band_guest_networks(xml, "2g")[one_and_only_relevant_index]
+        guest_networks_5g = WifiGuestNetworkSettings.__band_guest_networks(xml, "5g")[one_and_only_relevant_index]
 
         return GuestNetworkSettings(
             guest_networks_2g,
             guest_networks_5g,
         )
 
-    @staticmethod
-    def __compare_wifi_settings(old_settings, new_settings, interface_index, changes):
-        """
-        Compare two settings objects for changes and
-        return:
-            bln_changes: True if there were changes
-            changes: Python dict that contains the changes
-        """
-
-        def iterate_changes(old_settings, new_settings, changes):
-            for attr, old_value in old_settings.__dict__.items():
-                if isinstance(old_value, BandSetting):
-                    changes.update({attr: {}})
-                    iterate_changes(
-                        getattr(old_settings, attr),
-                        getattr(new_settings, attr),
-                        changes[attr],
-                    )
-                else:
-                    new_value = getattr(new_settings, attr)
-                    if old_value != new_value:
-                        changes.update({attr: f"{old_value} -> {new_value}"})
-                        bln_changes[0] = True
-
-        changes = {}
-        bln_changes = [False]
-        iterate_changes(
-            old_settings.guest_networks_2g[interface_index],
-            new_settings.guest_networks_2g[interface_index],
-            changes,
-        )
-        iterate_changes(
-            old_settings.guest_networks_5g[interface_index],
-            new_settings.guest_networks_5g[interface_index],
-            changes,
-        )
-        return bln_changes[0], changes
-
-    def __check_router_status(self, new_guest_network_settings, interface_index, debug):
-        """
-        Checks if (1) the new user settings were changed in the router (via checking
-        the getter fun:307 [WIRELESSGUESTNETWORK] in the router-xml-file), (2) prints out a
-        progress bar and (3) prints out if the process was successful.
-        """
-        router_settings = None
-
-        progress = 0
-
-        def print_progress_bar(progress, total, postfix=""):
-            progress = total if progress > total else progress
-            per_progress = int(progress / total * 100)
-            postfix = f"[{postfix}]" if postfix != "" else ""
-            print(
-                f"\r|{'█' * progress}{'-' * (total - progress)}| {per_progress}%, {progress}sec\t{postfix}",
-                end="",
-            )
-
-        total = 24
-        bln_changes = True
-        changes = ""
-        if debug:
-            print("\n--- WAITING FOR ROUTER TO UPDATE ---")
-        while progress < total and bln_changes is True:
-            time.sleep(3)
-            if debug:
-                print_progress_bar(progress, total, changes)
-            try:
-                router_settings = self.wifi_guest_network_settings
-                bln_changes, changes = self.__compare_wifi_settings(
-                    router_settings,
-                    new_guest_network_settings,
-                    interface_index,
-                    changes,
-                )
-            except Exception as e:
-                changes = str(e)
-        if debug:
-            if not bln_changes:
-                print("\n\n--- ROUTER SUCESSFULLY UPDATED ALL NEW WIFI SETTINGS! ---")
-            else:
-                print("\n\n--- CHANGES THAT DID NOT GET SET ---")
-                _, changes = self.__compare_wifi_settings(
-                    router_settings, new_guest_network_settings, interface_index
-                )
-                print(changes)
-        return bln_changes
-
-    def update_interface_guest_network_settings(
-        self, new_guest_network_settings, interface_index, debug=True
-    ):
+    def update_wifi_guest_network_settings(self, new_guest_network_settings):
         """
         Method for updating the wifi guest network settings. Uses fun:308.
+        The given new_guest_network_settings are applied to all currently enabled wifi bands.
+        Requires at least firmware CH7465LG-NCIP-6.15.30-1p3-1-NOSH.
         """
-        len_2g_list = len(new_guest_network_settings.guest_networks_2g)
-        len_5g_list = len(new_guest_network_settings.guest_networks_5g)
-        assert len_2g_list == len_5g_list
-        assert 0 <= interface_index < len_2g_list
-
         def transform_interface(interface_settings):
             out = []
             out.extend(
                 [
-                    ("Interface", interface_index + 1),
                     ("Enable", interface_settings.enable),
                     ("Ssid", interface_settings.ssid),
                     ("Hiden", interface_settings.hidden),
@@ -1208,26 +1117,11 @@ class WifiGuestNetworkSettings(object):
             )
 
             # Prefix 'wl', Postfix the band
-            return [(f"wl{k}{interface_settings.radio}", v) for (k, v) in out]
+            return [(f"wl{k}", v) for (k, v) in out]
 
-        out_s = []  # change
-        for item_2g, item_5g in zip(
-            transform_interface(
-                new_guest_network_settings.guest_networks_2g[interface_index]
-            ),
-            transform_interface(
-                new_guest_network_settings.guest_networks_5g[interface_index]
-            ),
-        ):
-            out_s.append(item_2g)
-            out_s.append(item_5g)
-
-        out_settings = OrderedDict(out_s)
+        out_settings = OrderedDict(transform_interface(new_guest_network_settings))
         self.modem.xml_setter(
             SetFunction.WIFI_GUEST_NETWORK_CONFIGURATION, out_settings
-        )
-        return self.__check_router_status(
-            new_guest_network_settings, interface_index, debug
         )
 
 

--- a/compal/__init__.py
+++ b/compal/__init__.py
@@ -1049,8 +1049,8 @@ class WifiGuestNetworkSettings(object):
         one_and_only_relevant_index = 2
 
         interfaces = {
-            '2g': list(xml.iter("Interface"))[one_and_only_relevant_index],
-            '5g': list(xml.iter("Interface5G"))[one_and_only_relevant_index],
+            "2g": list(xml.iter("Interface"))[one_and_only_relevant_index],
+            "5g": list(xml.iter("Interface5G"))[one_and_only_relevant_index],
         }
 
         def guest_xv(band, attr, coherce=True):
@@ -1067,16 +1067,20 @@ class WifiGuestNetworkSettings(object):
                 )
 
         return GuestNetworkSettings(
-            GuestNetworkEnabling(guest_xv('2g', "Enable") == 1, guest_xv('2g', "GuestMac")),
-            GuestNetworkEnabling(guest_xv('5g', "Enable") == 1, guest_xv('5g', "GuestMac")),
+            GuestNetworkEnabling(
+                guest_xv("2g", "Enable") == 1, guest_xv("2g", "GuestMac")
+            ),
+            GuestNetworkEnabling(
+                guest_xv("5g", "Enable") == 1, guest_xv("5g", "GuestMac")
+            ),
             GuestNetworkProperties(
-                guest_xv('2g', "BSSID"),
-                guest_xv('2g', "HideNetwork"),
-                guest_xv('2g', "GroupRekeyInterval"),
-                guest_xv('2g', "SecurityMode"),
-                guest_xv('2g', "PreSharedKey"),
-                guest_xv('2g', "WpaAlgorithm"),
-            )
+                guest_xv("2g", "BSSID"),
+                guest_xv("2g", "HideNetwork"),
+                guest_xv("2g", "GroupRekeyInterval"),
+                guest_xv("2g", "SecurityMode"),
+                guest_xv("2g", "PreSharedKey"),
+                guest_xv("2g", "WpaAlgorithm"),
+            ),
         )
 
     def update_wifi_guest_network_settings(self, properties, enable):
@@ -1086,15 +1090,17 @@ class WifiGuestNetworkSettings(object):
         The enabling has only effect on wifi bands that are currently switched on.
         Requires at least firmware CH7465LG-NCIP-6.15.30-1p3-1-NOSH.
         """
-        out_settings = OrderedDict([
-            ("wlEnable", 1 if enable else 2),
-            ("wlSsid", properties.ssid),
-            ("wlHiden", properties.hidden),
-            ("wlRekey", properties.re_key),
-            ("wlSecurity", properties.security),
-            ("wlPSkey", properties.pre_shared_key),
-            ("wlWpaalg", properties.wpa_algorithm),
-        ])
+        out_settings = OrderedDict(
+            [
+                ("wlEnable", 1 if enable else 2),
+                ("wlSsid", properties.ssid),
+                ("wlHiden", properties.hidden),
+                ("wlRekey", properties.re_key),
+                ("wlSecurity", properties.security),
+                ("wlPSkey", properties.pre_shared_key),
+                ("wlWpaalg", properties.wpa_algorithm),
+            ]
+        )
         self.modem.xml_setter(
             SetFunction.WIFI_GUEST_NETWORK_CONFIGURATION, out_settings
         )

--- a/compal/models.py
+++ b/compal/models.py
@@ -60,8 +60,8 @@ class InterfaceGuestNetworkSettings:
 
 @dataclass
 class GuestNetworkSettings:
-    guest_networks_2g: List[InterfaceGuestNetworkSettings] = None
-    guest_networks_5g: List[InterfaceGuestNetworkSettings] = None
+    guest_networks_2g: InterfaceGuestNetworkSettings = None
+    guest_networks_5g: InterfaceGuestNetworkSettings = None
 
 
 class FilterAction(Enum):

--- a/compal/models.py
+++ b/compal/models.py
@@ -44,12 +44,13 @@ class RadioSettings:
 
 
 @dataclass
-class InterfaceGuestNetworkSettings:
-    # read-only fields
-    radio: str
-    guest_mac: str
-    # editable-fields
-    enable: Optional[int] = None
+class GuestNetworkEnabling:
+    enabled: Optional[bool] = None
+    guest_mac: Optional[str] = None
+
+
+@dataclass
+class GuestNetworkProperties:
     ssid: Optional[str] = None
     hidden: Optional[int] = None
     re_key: Optional[int] = None
@@ -60,8 +61,9 @@ class InterfaceGuestNetworkSettings:
 
 @dataclass
 class GuestNetworkSettings:
-    guest_networks_2g: InterfaceGuestNetworkSettings = None
-    guest_networks_5g: InterfaceGuestNetworkSettings = None
+    enabling_2g: GuestNetworkEnabling
+    enabling_5g: GuestNetworkEnabling
+    properties: GuestNetworkProperties
 
 
 class FilterAction(Enum):

--- a/examples/guest_fun.py
+++ b/examples/guest_fun.py
@@ -20,15 +20,13 @@ def modem_setup(host, passwd):
     guest = WifiGuestNetworkSettings(modem)
     settings = guest.wifi_guest_network_settings
 
-    # Change enabling state of the 3rd (index 2) 2g-interface (the one also editable via the UI)
-    interface_index = 2
-    old_enabling_state = settings.guest_networks_2g[interface_index].enable
+    old_enabling_state = settings.guest_networks_2g.enable
     pprint.pprint('Current GUEST-NETWORK state: ' + ('ON' if old_enabling_state == 1 else 'OFF'))
 
-    settings.guest_networks_2g[interface_index].enable = 1 if old_enabling_state == 2 else 2
-    guest.update_interface_guest_network_settings(settings, interface_index)
+    settings.guest_networks_2g.enable = 1 if old_enabling_state == 2 else 2
+    guest.update_wifi_guest_network_settings(settings.guest_networks_2g)
 
-    new_enabling_state = guest.wifi_guest_network_settings.guest_networks_2g[interface_index].enable
+    new_enabling_state = guest.wifi_guest_network_settings.guest_networks_2g.enable
     pprint.pprint('New GUEST-NETWORK state: ' + ('ON' if new_enabling_state == 1 else 'OFF'))
 
     pprint.pprint(guest.wifi_guest_network_settings)

--- a/examples/guest_fun.py
+++ b/examples/guest_fun.py
@@ -20,16 +20,15 @@ def modem_setup(host, passwd):
     guest = WifiGuestNetworkSettings(modem)
     settings = guest.wifi_guest_network_settings
 
-    old_enabling_state = settings.guest_networks_2g.enable
-    pprint.pprint('Current GUEST-NETWORK state: ' + ('ON' if old_enabling_state == 1 else 'OFF'))
+    old_enabling_state = settings.enabling_2g.enabled
+    pprint.pprint('Current GUEST-NETWORK state: ' + ('ON' if old_enabling_state else 'OFF'))
 
-    settings.guest_networks_2g.enable = 1 if old_enabling_state == 2 else 2
-    guest.update_wifi_guest_network_settings(settings.guest_networks_2g)
+    guest.update_wifi_guest_network_settings(settings.properties, not old_enabling_state)
 
-    new_enabling_state = guest.wifi_guest_network_settings.guest_networks_2g.enable
-    pprint.pprint('New GUEST-NETWORK state: ' + ('ON' if new_enabling_state == 1 else 'OFF'))
-
-    pprint.pprint(guest.wifi_guest_network_settings)
+    settings = guest.wifi_guest_network_settings
+    new_enabling_state = settings.enabling_2g.enabled
+    pprint.pprint('New GUEST-NETWORK state: ' + ('ON' if new_enabling_state else 'OFF'))
+    pprint.pprint(settings)
 
     modem.logout()
 


### PR DESCRIPTION
Fixing issue #31. 
WifiGuestNetworkSettings.update_wifi_guest_network_settings works again with firmware 6.15.30-1p3-1-NOSH.
As the API of fun 308 was changed, this fix is not backward compatible to older firmware versions.
