### PR TITLE
Add ipv6 filter support

### DIFF
--- a/compal/__init__.py
+++ b/compal/__init__.py
@@ -46,8 +46,9 @@ class Compal:
     Basic functionality for the router's API
     """
 
-    def __init__(self, router_ip, key=None, username="admin", timeout=10):
+    def __init__(self, router_ip, key=None, send_token=True, username="admin", timeout=10):
         self.router_ip = router_ip
+        self.send_token = send_token
         self.username = username
         self.timeout = timeout
         self.key = key[:31] if key else key
@@ -141,7 +142,8 @@ class Compal:
         (Which is a code smell)
         """
         data = OrderedDict()
-        data["token"] = self.session_token
+        if self.send_token:
+            data["token"] = self.session_token
 
         if "fun" in _data:
             data["fun"] = _data.pop("fun")

--- a/compal/__init__.py
+++ b/compal/__init__.py
@@ -46,7 +46,7 @@ class Compal:
         self.router_ip = router_ip
         self.username = username
         self.timeout = timeout
-        self.key = key
+        self.key = key[:31] if key else key
 
         self.session = requests.Session()
         # limit the number of redirects
@@ -74,7 +74,7 @@ class Compal:
         LOGGER.info("Initial setup: english.")
 
         if new_key:
-            self.key = new_key
+            self.key = new_key[:31]
 
         if not self.key:
             raise ValueError("No key/password availalbe")
@@ -203,7 +203,7 @@ class Compal:
         res = self.xml_setter(
             SetFunction.LOGIN,
             OrderedDict(
-                [("Username", self.username), ("Password", key if key else self.key)]
+                [("Username", self.username), ("Password", key[:31] if key else self.key)]
             ),
         )
 
@@ -1386,7 +1386,7 @@ class FuncScanner(object):
     def __init__(self, modem, pos, key):
         self.modem = modem
         self.current_pos = pos
-        self.key = key
+        self.key = key[:31]
         self.last_login = -1
 
     @property

--- a/compal/__init__.py
+++ b/compal/__init__.py
@@ -46,7 +46,9 @@ class Compal:
     Basic functionality for the router's API
     """
 
-    def __init__(self, router_ip, key=None, send_token=True, username="admin", timeout=10):
+    def __init__(
+        self, router_ip, key=None, send_token=True, username="admin", timeout=10
+    ):
         self.router_ip = router_ip
         self.send_token = send_token
         self.username = username

--- a/compal/__init__.py
+++ b/compal/__init__.py
@@ -42,8 +42,9 @@ class Compal:
     Basic functionality for the router's API
     """
 
-    def __init__(self, router_ip, key=None, timeout=10):
+    def __init__(self, router_ip, key=None, username = 'admin', timeout=10):
         self.router_ip = router_ip
+        self.username = username
         self.timeout = timeout
         self.key = key
 
@@ -86,7 +87,7 @@ class Compal:
         # Login or change password? Not sure.
         self.xml_setter(
             SetFunction.LOGIN,
-            OrderedDict([("Username", "admin"), ("Password", self.key)]),
+            OrderedDict([("Username", self.username), ("Password", self.key)]),
         )
         # Get current wifi settings (?)
         self.xml_getter(GetFunction.WIRELESSBASIC, {})
@@ -202,7 +203,7 @@ class Compal:
         res = self.xml_setter(
             SetFunction.LOGIN,
             OrderedDict(
-                [("Username", "admin"), ("Password", key if key else self.key)]
+                [("Username", self.username), ("Password", key if key else self.key)]
             ),
         )
 

--- a/compal/models.py
+++ b/compal/models.py
@@ -84,6 +84,53 @@ class NatMode(IntEnum):
     enabled = 1
     disabled = 2
 
+class FilterIpRange(IntEnum):
+    """
+    Filter rule ip range enum
+    """
+    all = 0
+    single = 1
+    range = 2
+
+class RuleDir(IntEnum):
+    """
+    Filter rule direction
+    """
+    incoming = 0
+    outgoing = 1
+
+class IPv6FilterRuleProto(IntEnum):
+    """
+    protocol (from form):
+    """
+    all = 0
+    udp = 1
+    tcp = 2
+    udp_tcp = 3
+    icmpv6 = 4
+    esp = 5
+    ah = 6
+    gre = 7
+    ipv6encap = 8
+    ipv4encap = 9
+    ipv6fragment = 10
+    l2tp = 11
+
+@dataclass
+class IPv6FilterRule:
+    dir: Optional[RuleDir] = None
+    idd: Optional[int] = None
+    src_addr: Optional[str] = None
+    src_prefix: Optional[int] = None
+    dst_addr: Optional[str] = None
+    dst_prefix: Optional[int] = None
+    src_sport: Optional[int] = None # start port
+    src_eport: Optional[int] = None # end port
+    dst_sport: Optional[int] = None # start port
+    dst_eport: Optional[int] = None # end port
+    protocol: Optional[IPv6FilterRuleProto] = None
+    allow: Optional[bool] = None
+    enabled: Optional[bool] = None
 
 @dataclass
 class PortForward:

--- a/compal/models.py
+++ b/compal/models.py
@@ -1,6 +1,6 @@
 """Objects used by CH7465LG"""
 from dataclasses import dataclass
-from enum import Enum
+from enum import IntEnum
 from typing import Optional, List
 
 
@@ -66,7 +66,7 @@ class GuestNetworkSettings:
     properties: GuestNetworkProperties
 
 
-class FilterAction(Enum):
+class FilterAction(IntEnum):
     """
     Filter action, used by internet access filters
     """
@@ -76,7 +76,7 @@ class FilterAction(Enum):
     enable = 3
 
 
-class NatMode(Enum):
+class NatMode(IntEnum):
     """
     Values for NAT-Mode
     """
@@ -98,7 +98,7 @@ class PortForward:
     lan_ip: Optional[str] = None
 
 
-class Proto(Enum):
+class Proto(IntEnum):
     """
     protocol (from form): 1 = tcp, 2 = udp, 3 = both
     """
@@ -108,7 +108,7 @@ class Proto(Enum):
     both = 3
 
 
-class TimerMode(Enum):
+class TimerMode(IntEnum):
     """
     Timermodes used for internet access filtering
     """

--- a/compal/models.py
+++ b/compal/models.py
@@ -84,25 +84,31 @@ class NatMode(IntEnum):
     enabled = 1
     disabled = 2
 
+
 class FilterIpRange(IntEnum):
     """
     Filter rule ip range enum
     """
+
     all = 0
     single = 1
     range = 2
+
 
 class RuleDir(IntEnum):
     """
     Filter rule direction
     """
+
     incoming = 0
     outgoing = 1
+
 
 class IPv6FilterRuleProto(IntEnum):
     """
     protocol (from form):
     """
+
     all = 0
     udp = 1
     tcp = 2
@@ -116,6 +122,7 @@ class IPv6FilterRuleProto(IntEnum):
     ipv6fragment = 10
     l2tp = 11
 
+
 @dataclass
 class IPv6FilterRule:
     dir: Optional[RuleDir] = None
@@ -124,13 +131,14 @@ class IPv6FilterRule:
     src_prefix: Optional[int] = None
     dst_addr: Optional[str] = None
     dst_prefix: Optional[int] = None
-    src_sport: Optional[int] = None # start port
-    src_eport: Optional[int] = None # end port
-    dst_sport: Optional[int] = None # start port
-    dst_eport: Optional[int] = None # end port
+    src_sport: Optional[int] = None  # start port
+    src_eport: Optional[int] = None  # end port
+    dst_sport: Optional[int] = None  # start port
+    dst_eport: Optional[int] = None  # end port
     protocol: Optional[IPv6FilterRuleProto] = None
     allow: Optional[bool] = None
     enabled: Optional[bool] = None
+
 
 @dataclass
 class PortForward:


### PR DESCRIPTION
This PR adds support to get, create, disable and delete IPv6 filter rules.
Besides from that I made some small adjustments that I might move in different PRs (or drop) if desired.
- While analyzing the API for manipulating the IPv6 filter rules, I noticed that for my modem the username 'NULL' is used, so I added a parameter. But it seems to work with 'admin' too, so probably doesn't really matter.
- In the beginning I was unable to login and after longer investigations it turns out that my modem truncates passwords to a length of max. 31 chars. Hence, the login failed because the longer password was sent to the modem which it did not accept. Not sure if this limitation exists for every provider though. So this might be great if others could confirm this behavior.

PS: I have only little python programming experience, so any feedback is welcome^^